### PR TITLE
Fix #30, replace deprecated URL by the new one for the OAuth authentication flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0 - 2021-10-13](https://github.com/braincube-io/python-connector/compare/2.4.1...2.5.0)
+
 ### Changed
 
 - #[25](https://github.com/braincube-io/python-connector/issues/25): support `{braincube-name}` as a placeholder in `braincube_base_url` configuration.
+- #[30](https://github.com/braincube-io/python-connector/issues/25): use new SSO URL for OAuth authentication flow
 
 ## [2.4.1 - 2021-04-22](https://github.com/braincube-io/python-connector/compare/2.4.0...2.4.1)
 

--- a/braincube_connector/client.py
+++ b/braincube_connector/client.py
@@ -135,7 +135,7 @@ class Client(base.Base):
                 )
             }
             access_data = self.request_ws(
-                "sso-server/rest/session/openWithToken", headers=headers, api=False
+                "sso-server/ws/oauth2/session", headers=headers, api=False
             )
             return {constants.SSO_TOKEN_KEY: access_data["token"]}
         raise KeyError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -82,7 +82,7 @@ def test_request_braincubes(mock_client):
 @responses.activate
 def test_build_authentication_oauth2(mock_client):
     """Test the build authentication function for an oauth2 token."""
-    mock_url = "https://a.b/sso-server/rest/session/openWithToken"
+    mock_url = "https://a.b/sso-server/ws/oauth2/session"
     responses.add(responses.GET, mock_url, status=200, json={"token": "abcd"})
     header = mock_client._build_authentication({constants.OAUTH2_KEY: "efgh"})
     assert header == {constants.SSO_TOKEN_KEY: "abcd"}


### PR DESCRIPTION
Some endpoints of our SSO are deprecated, we need to use the new ones.

For this project, we are only concerned by the OAuth authorisation flow.

Closes #30 